### PR TITLE
Adds "reporters" to the app

### DIFF
--- a/elixir/lib/fractals.ex
+++ b/elixir/lib/fractals.ex
@@ -40,11 +40,13 @@ defmodule Fractals do
 
   @spec fractalize(Fractals.Params.t()) :: :ok
   def fractalize(params) do
-    send(params.source_pid, {:starting, self(), params})
-
     if unimplemented?(params.fractal) do
-      send(params.source_pid, {:skipping, self(), params, "not implemented"})
+      send(
+        params.source_pid,
+        {:skipping, params, reason: "fractal not implemented", from: self()}
+      )
     else
+      send(params.source_pid, {:starting, params, from: self()})
       GridWorker.work(Fractals.GridWorker, params)
     end
 

--- a/elixir/lib/fractals.ex
+++ b/elixir/lib/fractals.ex
@@ -36,7 +36,8 @@ defmodule Fractals do
       Random,
       OutputWorkerSupervisor,
       ConversionWorker,
-      ReporterSupervisor
+      ReporterSupervisor,
+      Broadcaster
     ]
 
     Supervisor.start_link(staged ++ unstaged, strategy: :one_for_one)

--- a/elixir/lib/fractals.ex
+++ b/elixir/lib/fractals.ex
@@ -17,6 +17,8 @@ defmodule Fractals do
     Reporters.Broadcaster
   }
 
+  alias Fractals.Reporters.Supervisor, as: ReporterSupervisor
+
   @unimplemented Application.get_env(:fractals, :unimplemented)
 
   @impl Application
@@ -33,7 +35,8 @@ defmodule Fractals do
     unstaged = [
       Random,
       OutputWorkerSupervisor,
-      ConversionWorker
+      ConversionWorker,
+      ReporterSupervisor
     ]
 
     Supervisor.start_link(staged ++ unstaged, strategy: :one_for_one)

--- a/elixir/lib/fractals.ex
+++ b/elixir/lib/fractals.ex
@@ -13,7 +13,8 @@ defmodule Fractals do
     GridWorker,
     OutputManager,
     OutputWorkerSupervisor,
-    Params
+    Params,
+    Reporters.Broadcaster
   }
 
   @unimplemented Application.get_env(:fractals, :unimplemented)
@@ -41,12 +42,9 @@ defmodule Fractals do
   @spec fractalize(Fractals.Params.t()) :: :ok
   def fractalize(params) do
     if unimplemented?(params.fractal) do
-      send(
-        params.source_pid,
-        {:skipping, params, reason: "fractal not implemented", from: self()}
-      )
+      Broadcaster.report(:skipping, params, reason: "fractal not implemented", from: self())
     else
-      send(params.source_pid, {:starting, params, from: self()})
+      Broadcaster.report(:starting, params, from: self())
       GridWorker.work(Fractals.GridWorker, params)
     end
 

--- a/elixir/lib/fractals/cli.ex
+++ b/elixir/lib/fractals/cli.ex
@@ -4,6 +4,7 @@ defmodule Fractals.CLI do
   """
 
   alias Fractals.Params
+  alias Fractals.Reporters.{FilenameCountdown, Stdout}
 
   @spec main(OptionParser.argv()) :: :ok
   def main(args) do
@@ -15,8 +16,8 @@ defmodule Fractals.CLI do
   def go(flags, filenames) do
     base_params = flags |> Params.parse()
 
-    Fractals.Reporters.FilenameCountdown.start_link(filenames: filenames, for: self())
-    Fractals.Reporters.Stdout.start_link([])
+    FilenameCountdown.start_link(filenames: filenames, for: self())
+    Stdout.start_link([])
 
     filenames
     |> Enum.each(fn params_filename ->

--- a/elixir/lib/fractals/cli.ex
+++ b/elixir/lib/fractals/cli.ex
@@ -24,12 +24,21 @@ defmodule Fractals.CLI do
       |> Fractals.fractalize()
     end)
 
+    Fractals.Reports.FilenameCountdown.start_link(filenames: filenames, for: self())
     Fractals.Reports.Stdout.start_link([])
     watch(filenames)
   end
 
   @spec watch([String.t()]) :: :ok
   def watch([]) do
+    receive do
+      {:filenames_empty, _reason} ->
+        IO.puts("I GOT THE MESSAGE!!!!")
+    after
+      5000 ->
+        IO.puts("NOOOOOO MESSAGE!!!!!")
+    end
+
     IO.puts("ALL DONE!")
     IO.puts("Have a nice day.")
     :ok
@@ -39,18 +48,42 @@ defmodule Fractals.CLI do
     receive do
       {:starting, params, opts} ->
         Fractals.Reports.Stdout.report(Fractals.Reports.Stdout, {:starting, params, opts})
+
+        Fractals.Reports.FilenameCountdown.report(
+          Fractals.Reports.FilenameCountdown,
+          {:starting, params, opts}
+        )
+
         watch(filenames)
 
       {:writing, params, opts} ->
         Fractals.Reports.Stdout.report(Fractals.Reports.Stdout, {:writing, params, opts})
+
+        Fractals.Reports.FilenameCountdown.report(
+          Fractals.Reports.FilenameCountdown,
+          {:writing, params, opts}
+        )
+
         watch(filenames)
 
       {:skipping, params, opts} ->
         Fractals.Reports.Stdout.report(Fractals.Reports.Stdout, {:skipping, params, opts})
+
+        Fractals.Reports.FilenameCountdown.report(
+          Fractals.Reports.FilenameCountdown,
+          {:skipping, params, opts}
+        )
+
         watch(List.delete(filenames, params.params_filename))
 
       {:done, params, opts} ->
         Fractals.Reports.Stdout.report(Fractals.Reports.Stdout, {:done, params, opts})
+
+        Fractals.Reports.FilenameCountdown.report(
+          Fractals.Reports.FilenameCountdown,
+          {:done, params, opts}
+        )
+
         watch(List.delete(filenames, params.params_filename))
     end
   end

--- a/elixir/lib/fractals/cli.ex
+++ b/elixir/lib/fractals/cli.ex
@@ -7,7 +7,7 @@ defmodule Fractals.CLI do
 
   @spec main(OptionParser.argv()) :: :ok
   def main(args) do
-    {flags, filenames, _} = OptionParser.parse(args)
+    {flags, filenames, _} = OptionParser.parse(args, switches: [params_filename: :string])
     go(flags, filenames)
   end
 

--- a/elixir/lib/fractals/cli.ex
+++ b/elixir/lib/fractals/cli.ex
@@ -22,7 +22,6 @@ defmodule Fractals.CLI do
     |> Enum.each(fn params_filename ->
       []
       |> Keyword.put(:params_filename, params_filename)
-      |> Keyword.put(:source_pid, self())
       |> Params.process(base_params)
       |> Fractals.fractalize()
     end)

--- a/elixir/lib/fractals/cli.ex
+++ b/elixir/lib/fractals/cli.ex
@@ -24,6 +24,7 @@ defmodule Fractals.CLI do
       |> Fractals.fractalize()
     end)
 
+    Fractals.Reports.Stdout.start_link([])
     watch(filenames)
   end
 
@@ -36,22 +37,20 @@ defmodule Fractals.CLI do
 
   def watch(filenames) do
     receive do
-      {:starting, params, _opts} ->
-        IO.puts("starting #{params.output_filename}")
+      {:starting, params, opts} ->
+        Fractals.Reports.Stdout.report(Fractals.Reports.Stdout, {:starting, params, opts})
         watch(filenames)
 
       {:writing, params, opts} ->
-        chunk_number = Keyword.get(opts, :chunk_number)
-        IO.puts("writing #{chunk_number}/#{params.chunk_count} to #{params.ppm_filename}")
+        Fractals.Reports.Stdout.report(Fractals.Reports.Stdout, {:writing, params, opts})
         watch(filenames)
 
       {:skipping, params, opts} ->
-        reason = Keyword.get(opts, :reason)
-        IO.puts("skipping #{params.output_filename}: #{reason}")
+        Fractals.Reports.Stdout.report(Fractals.Reports.Stdout, {:skipping, params, opts})
         watch(List.delete(filenames, params.params_filename))
 
-      {:done, params, _opts} ->
-        IO.puts("finished #{params.output_filename}")
+      {:done, params, opts} ->
+        Fractals.Reports.Stdout.report(Fractals.Reports.Stdout, {:done, params, opts})
         watch(List.delete(filenames, params.params_filename))
     end
   end

--- a/elixir/lib/fractals/cli.ex
+++ b/elixir/lib/fractals/cli.ex
@@ -36,19 +36,21 @@ defmodule Fractals.CLI do
 
   def watch(filenames) do
     receive do
-      {:starting, _from, params} ->
+      {:starting, params, _opts} ->
         IO.puts("starting #{params.output_filename}")
         watch(filenames)
 
-      {:writing, chunk_number, params} ->
+      {:writing, params, opts} ->
+        chunk_number = Keyword.get(opts, :chunk_number)
         IO.puts("writing #{chunk_number}/#{params.chunk_count} to #{params.ppm_filename}")
         watch(filenames)
 
-      {:skipping, _, params, reason} ->
+      {:skipping, params, opts} ->
+        reason = Keyword.get(opts, :reason)
         IO.puts("skipping #{params.output_filename}: #{reason}")
         watch(List.delete(filenames, params.params_filename))
 
-      {:done, _, params} ->
+      {:done, params, _opts} ->
         IO.puts("finished #{params.output_filename}")
         watch(List.delete(filenames, params.params_filename))
     end

--- a/elixir/lib/fractals/cli.ex
+++ b/elixir/lib/fractals/cli.ex
@@ -5,7 +5,6 @@ defmodule Fractals.CLI do
 
   alias Fractals.Params
   alias Fractals.Reporters.{Broadcaster, FilenameCountdown, Stdout}
-  alias Fractals.Reporters.Supervisor, as: ReporterSupervisor
 
   @spec main(OptionParser.argv()) :: :ok
   def main(args) do
@@ -35,7 +34,6 @@ defmodule Fractals.CLI do
 
   @spec add_reporters([String.t()]) :: :ok
   def add_reporters(filenames) do
-    ReporterSupervisor.add_reporter(Broadcaster)
     Broadcaster.add_reporter(FilenameCountdown, filenames: filenames, for: self())
     Broadcaster.add_reporter(Stdout)
     :ok

--- a/elixir/lib/fractals/conversion_worker.ex
+++ b/elixir/lib/fractals/conversion_worker.ex
@@ -56,7 +56,7 @@ defmodule Fractals.ConversionWorker do
     {:noreply, state}
   end
 
-  @spec done(module, Params.t()) :: any
+  @spec done((atom, Params.t(), keyword -> any), Params.t()) :: any
   defp done(broadcast, params) do
     broadcast.(:done, params, from: self())
   end

--- a/elixir/lib/fractals/conversion_worker.ex
+++ b/elixir/lib/fractals/conversion_worker.ex
@@ -5,41 +5,42 @@ defmodule Fractals.ConversionWorker do
 
   use GenServer
 
-  alias Fractals.{ImageMagick, Params}
-
-  @spec convert(Params.t()) :: any
-  def convert(params) do
-    convert(__MODULE__, params)
-  end
+  alias Fractals.{ImageMagick, Params, Reporters.Broadcaster}
 
   # Client
 
   @spec start_link(keyword) :: GenServer.on_start()
   def(start_link(options \\ [])) do
     convert = Keyword.get(options, :convert, &ImageMagick.convert/2)
+    broadcast = Keyword.get(options, :broadcast, &Broadcaster.report/3)
     name = Keyword.get(options, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, convert, name: name)
+
+    state = %{
+      convert: convert,
+      broadcast: broadcast
+    }
+
+    GenServer.start_link(__MODULE__, state, name: name)
   end
 
   @spec convert(pid | atom, Params.t()) :: :ok
-  def convert(pid, params) do
+  def convert(pid \\ __MODULE__, params) do
     GenServer.cast(pid, {:convert, params})
   end
 
   # Server
 
   @impl GenServer
-  def init(convert) do
-    {:ok, convert}
+  def init(state) do
+    {:ok, state}
   end
 
   @impl GenServer
-  def handle_cast({:convert, params}, convert) do
+  def handle_cast({:convert, params}, %{convert: convert, broadcast: broadcast} = state) do
     case Path.extname(params.output_filename) do
       ".ppm" ->
         # OutputWorker already wrote a PPM file
-        done(params)
-        {:noreply, convert}
+        :ok
 
       ".png" ->
         root_filename =
@@ -49,18 +50,14 @@ defmodule Fractals.ConversionWorker do
 
         ppm_filename = root_filename <> ".ppm"
         convert.(ppm_filename, params.output_filename)
-        done(params)
-        {:noreply, convert}
     end
+
+    done(broadcast, params)
+    {:noreply, state}
   end
 
-  @spec done(Params.t()) :: any
-  defp done(params) do
-    notify_source_pid(params, {:done, params, from: self()})
-  end
-
-  @spec notify_source_pid(Params.t(), {atom, pid, Params.t()}) :: any
-  defp notify_source_pid(params, message) do
-    send(params.source_pid, message)
+  @spec done(module, Params.t()) :: any
+  defp done(broadcast, params) do
+    broadcast.(:done, params, from: self())
   end
 end

--- a/elixir/lib/fractals/conversion_worker.ex
+++ b/elixir/lib/fractals/conversion_worker.ex
@@ -56,7 +56,7 @@ defmodule Fractals.ConversionWorker do
 
   @spec done(Params.t()) :: any
   defp done(params) do
-    notify_source_pid(params, {:done, self(), params})
+    notify_source_pid(params, {:done, params, from: self()})
   end
 
   @spec notify_source_pid(Params.t(), {atom, pid, Params.t()}) :: any

--- a/elixir/lib/fractals/output_worker.ex
+++ b/elixir/lib/fractals/output_worker.ex
@@ -93,7 +93,7 @@ defmodule Fractals.OutputWorker do
 
   @spec write_chunk(non_neg_integer, [String.t()], Params.t()) :: :ok
   defp write_chunk(chunk_number, data, params) do
-    notify_source_pid(params, {:writing, chunk_number, params})
+    notify_source_pid(params, {:writing, params, chunk_number: chunk_number})
     lines_to_file(data, params)
   end
 
@@ -102,7 +102,8 @@ defmodule Fractals.OutputWorker do
     IO.write(params.output_pid, add_newlines(lines))
   end
 
-  @spec notify_source_pid(Params.t(), {:writing, non_neg_integer, Params.t()}) :: any
+  @spec notify_source_pid(Params.t(), {:writing, Params.t(), chunk_number: non_neg_integer}) ::
+          any
   defp notify_source_pid(params, message) do
     send(params.source_pid, message)
   end

--- a/elixir/lib/fractals/output_worker.ex
+++ b/elixir/lib/fractals/output_worker.ex
@@ -7,8 +7,7 @@ defmodule Fractals.OutputWorker do
 
   use GenServer
 
-  alias Fractals.Output.OutputState
-  alias Fractals.Params
+  alias Fractals.{Output.OutputState, Params, Reporters.Broadcaster}
 
   # Client API
 
@@ -93,19 +92,13 @@ defmodule Fractals.OutputWorker do
 
   @spec write_chunk(non_neg_integer, [String.t()], Params.t()) :: :ok
   defp write_chunk(chunk_number, data, params) do
-    notify_source_pid(params, {:writing, params, chunk_number: chunk_number})
+    Broadcaster.report(:writing, params, chunk_number: chunk_number)
     lines_to_file(data, params)
   end
 
   @spec lines_to_file([String.t()], Params.t()) :: :ok
   defp lines_to_file(lines, params) do
     IO.write(params.output_pid, add_newlines(lines))
-  end
-
-  @spec notify_source_pid(Params.t(), {:writing, Params.t(), chunk_number: non_neg_integer}) ::
-          any
-  defp notify_source_pid(params, message) do
-    send(params.source_pid, message)
   end
 
   @spec add_newlines([String.t()]) :: [[String.t()]]

--- a/elixir/lib/fractals/output_worker_supervisor.ex
+++ b/elixir/lib/fractals/output_worker_supervisor.ex
@@ -14,6 +14,7 @@ defmodule Fractals.OutputWorkerSupervisor do
 
   # Server
 
+  @impl DynamicSupervisor
   def init(:ok) do
     DynamicSupervisor.init(strategy: :one_for_one)
   end

--- a/elixir/lib/fractals/params.ex
+++ b/elixir/lib/fractals/params.ex
@@ -128,6 +128,7 @@ defmodule Fractals.Params do
     %{params | attribute => parse_value(attribute, value)}
   end
 
+  @spec parse_value(atom, String.t()) :: any
   defp parse_value(:fractal, value) do
     String.to_atom(String.downcase(value))
   end
@@ -155,14 +156,17 @@ defmodule Fractals.Params do
   # Compute
   # **********
 
+  @spec compute(Params.t()) :: Params.t()
   defp compute(params) do
     Enum.reduce(@computed_attributes, params, &compute_attribute/2)
   end
 
+  @spec compute_attribute(atom, Params.t()) :: Params.t()
   defp compute_attribute(attribute, params) do
     %{params | attribute => compute_value(attribute, params)}
   end
 
+  @spec compute_value(atom, Params.t()) :: any
   defp compute_value(:id, _params) do
     UUID.uuid1()
   end
@@ -207,10 +211,12 @@ defmodule Fractals.Params do
     end
   end
 
+  @spec output_basepath(String.t(), Params.t()) :: String.t()
   defp output_basepath(filename, params) do
     Path.join(params.output_directory, basename(filename))
   end
 
+  @spec basename(String.t()) :: String.t()
   defp basename(filename) do
     filename
     |> Path.basename(".yml")
@@ -222,10 +228,12 @@ defmodule Fractals.Params do
   # Helpers
   # *******
 
+  @spec symbolize(Enumerable.t()) :: map
   defp symbolize(params) do
     for {key, val} <- params, into: %{}, do: {to_atom(key), val}
   end
 
+  @spec to_atom(atom | String.t()) :: atom
   defp to_atom(key) when is_atom(key), do: key
   defp to_atom(key), do: String.to_atom(Macro.underscore(key))
 end

--- a/elixir/lib/fractals/params.ex
+++ b/elixir/lib/fractals/params.ex
@@ -30,8 +30,7 @@ defmodule Fractals.Params do
           output_directory: String.t() | nil,
           output_filename: String.t() | nil,
           ppm_filename: String.t() | nil,
-          output_pid: pid | nil,
-          source_pid: pid | nil
+          output_pid: pid | nil
         }
 
   defstruct [
@@ -60,9 +59,7 @@ defmodule Fractals.Params do
     :output_directory,
     :output_filename,
     :ppm_filename,
-    :output_pid,
-    # processes
-    :source_pid
+    :output_pid
   ]
 
   @zero Complex.new(0.0)

--- a/elixir/lib/fractals/reporters/broadcaster.ex
+++ b/elixir/lib/fractals/reporters/broadcaster.ex
@@ -3,15 +3,46 @@ defmodule Fractals.Reporters.Broadcaster do
   Broadcasts messages to reporters.
   """
 
-  alias Fractals.Params
-  alias Fractals.Reporters.{FilenameCountdown, Stdout}
+  use GenServer
 
-  @reporters [Stdout, FilenameCountdown]
+  alias Fractals.Params
+  alias Fractals.Reporters.Supervisor
+
+  # client
+
+  def start_link(reporters \\ []) do
+    GenServer.start_link(__MODULE__, reporters, name: __MODULE__)
+  end
+
+  @spec add_reporter(module, any) :: :ok
+  def add_reporter(reporter, args \\ []) do
+    GenServer.cast(__MODULE__, {:add, reporter, args})
+  end
 
   @spec report(atom, Params.t(), keyword) :: :ok
   def report(tag, params, opts \\ []) do
-    Enum.each(@reporters, fn x ->
-      GenServer.cast(x, {tag, params, opts})
+    GenServer.cast(__MODULE__, {:report, {tag, params, opts}})
+  end
+
+  # server
+
+  @impl GenServer
+  def init(reporters) do
+    {:ok, reporters}
+  end
+
+  @impl GenServer
+  def handle_cast({:add, reporter, args}, reporters) do
+    Supervisor.add_reporter(reporter, args)
+    {:noreply, [reporter | reporters]}
+  end
+
+  @impl GenServer
+  def handle_cast({:report, {tag, params, opts}}, reporters) do
+    Enum.each(reporters, fn reporter ->
+      GenServer.cast(reporter, {tag, params, opts})
     end)
+
+    {:noreply, reporters}
   end
 end

--- a/elixir/lib/fractals/reporters/broadcaster.ex
+++ b/elixir/lib/fractals/reporters/broadcaster.ex
@@ -3,6 +3,7 @@ defmodule Fractals.Reporters.Broadcaster do
   Broadcasts messages to reporters.
   """
 
+  alias Fractals.Params
   alias Fractals.Reporters.{FilenameCountdown, Stdout}
 
   @reporters [Stdout, FilenameCountdown]

--- a/elixir/lib/fractals/reporters/broadcaster.ex
+++ b/elixir/lib/fractals/reporters/broadcaster.ex
@@ -1,0 +1,16 @@
+defmodule Fractals.Reporters.Broadcaster do
+  @moduledoc """
+  Broadcasts messages to reporters.
+  """
+
+  alias Fractals.Reporters.{FilenameCountdown, Stdout}
+
+  @reporters [Stdout, FilenameCountdown]
+
+  @spec report(atom, Params.t(), keyword) :: :ok
+  def report(tag, params, opts \\ []) do
+    Enum.each(@reporters, fn x ->
+      GenServer.cast(x, {tag, params, opts})
+    end)
+  end
+end

--- a/elixir/lib/fractals/reporters/broadcaster.ex
+++ b/elixir/lib/fractals/reporters/broadcaster.ex
@@ -16,7 +16,7 @@ defmodule Fractals.Reporters.Broadcaster do
 
   @spec add_reporter(module, any) :: :ok
   def add_reporter(reporter, args \\ []) do
-    GenServer.cast(__MODULE__, {:add, reporter, args})
+    GenServer.call(__MODULE__, {:add, reporter, args})
   end
 
   @spec report(atom, Params.t(), keyword) :: :ok
@@ -32,9 +32,9 @@ defmodule Fractals.Reporters.Broadcaster do
   end
 
   @impl GenServer
-  def handle_cast({:add, reporter, args}, reporters) do
+  def handle_call({:add, reporter, args}, _from, reporters) do
     Supervisor.add_reporter(reporter, args)
-    {:noreply, [reporter | reporters]}
+    {:reply, :ok, [reporter | reporters]}
   end
 
   @impl GenServer

--- a/elixir/lib/fractals/reporters/filename_countdown.ex
+++ b/elixir/lib/fractals/reporters/filename_countdown.ex
@@ -1,0 +1,63 @@
+defmodule Fractals.Reports.FilenameCountdown do
+  @moduledoc """
+  GenServer to keep track of the filenames that have been queued up.
+
+  When all of the files are processed, we notify a process (probably a CLI process) that it can stop.
+  """
+
+  use GenServer
+
+  alias Fractals.Params
+
+  # client
+
+  @spec start_link(keyword | map) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @spec report(module | pid, {atom, Params.t(), keyword}) :: :ok
+  def report(pid, message) do
+    GenServer.cast(pid, message)
+  end
+
+  # server
+
+  @ignored_tags [:starting, :writing]
+
+  def init(state) do
+    {:ok, Enum.into(state, %{})}
+  end
+
+  def handle_cast({:done, params, _opts}, state) do
+    params.filename
+    |> file_done(state)
+    |> response
+  end
+
+  def handle_cast({:skipping, params, _opts}, state) do
+    params.filename
+    |> file_done(state)
+    |> response
+  end
+
+  def handle_cast({tag, _params, _opts}, state) when tag in @ignored_tags do
+    response(state)
+  end
+
+  def terminate(reason, %{for: pid}) do
+    send(pid, {:filenames_empty, reason})
+  end
+
+  def file_done(filename, %{filenames: filenames} = state) do
+    Map.put(state, :filenames, List.delete(filenames, filename))
+  end
+
+  def response(%{filenames: []} = state) do
+    {:stop, "all fractals processed", state}
+  end
+
+  def response(state) do
+    {:noreply, state}
+  end
+end

--- a/elixir/lib/fractals/reporters/filename_countdown.ex
+++ b/elixir/lib/fractals/reporters/filename_countdown.ex
@@ -1,4 +1,4 @@
-defmodule Fractals.Reports.FilenameCountdown do
+defmodule Fractals.Reporters.FilenameCountdown do
   @moduledoc """
   GenServer to keep track of the filenames that have been queued up.
 
@@ -7,18 +7,11 @@ defmodule Fractals.Reports.FilenameCountdown do
 
   use GenServer
 
-  alias Fractals.Params
-
   # client
 
   @spec start_link(keyword | map) :: GenServer.on_start()
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
-  end
-
-  @spec report(module | pid, {atom, Params.t(), keyword}) :: :ok
-  def report(pid, message) do
-    GenServer.cast(pid, message)
   end
 
   # server
@@ -30,13 +23,13 @@ defmodule Fractals.Reports.FilenameCountdown do
   end
 
   def handle_cast({:done, params, _opts}, state) do
-    params.filename
+    params.params_filename
     |> file_done(state)
     |> response
   end
 
   def handle_cast({:skipping, params, _opts}, state) do
-    params.filename
+    params.params_filename
     |> file_done(state)
     |> response
   end

--- a/elixir/lib/fractals/reporters/filename_countdown.ex
+++ b/elixir/lib/fractals/reporters/filename_countdown.ex
@@ -18,34 +18,42 @@ defmodule Fractals.Reporters.FilenameCountdown do
 
   @ignored_tags [:starting, :writing]
 
+  @impl GenServer
   def init(state) do
     {:ok, Enum.into(state, %{})}
   end
 
+  @impl GenServer
   def handle_cast({:done, params, _opts}, state) do
     params.params_filename
     |> file_done(state)
     |> response
   end
 
+  @impl GenServer
   def handle_cast({:skipping, params, _opts}, state) do
     params.params_filename
     |> file_done(state)
     |> response
   end
 
+  @impl GenServer
   def handle_cast({tag, _params, _opts}, state) when tag in @ignored_tags do
     response(state)
   end
 
+  @impl GenServer
   def terminate(reason, %{for: pid}) do
     send(pid, {:filenames_empty, reason})
   end
 
+  @spec file_done(String.t(), %{filenames: [String.t()]}) :: %{filenames: [String.t()]}
   def file_done(filename, %{filenames: filenames} = state) do
     Map.put(state, :filenames, List.delete(filenames, filename))
   end
 
+  @spec response(%{filenames: [String.t()]}) ::
+          {:stop, String.t(), %{filenames: [String.t()]}} | {:noreply, %{filenames: [String.t()]}}
   def response(%{filenames: []} = state) do
     {:stop, "all fractals processed", state}
   end

--- a/elixir/lib/fractals/reporters/stdout.ex
+++ b/elixir/lib/fractals/reporters/stdout.ex
@@ -1,4 +1,4 @@
-defmodule Fractals.Reports.Stdout do
+defmodule Fractals.Reporters.Stdout do
   @moduledoc """
   Outputs messages to stdout.
   """
@@ -11,11 +11,6 @@ defmodule Fractals.Reports.Stdout do
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
-  end
-
-  @spec report(module | pid, {atom, Params.t(), keyword}) :: :ok
-  def report(pid, message) do
-    GenServer.cast(pid, message)
   end
 
   # server

--- a/elixir/lib/fractals/reporters/stdout.ex
+++ b/elixir/lib/fractals/reporters/stdout.ex
@@ -1,0 +1,48 @@
+defmodule Fractals.Reports.Stdout do
+  @moduledoc """
+  Outputs messages to stdout.
+  """
+
+  use GenServer
+
+  @type tag :: :starting | :writing | :skipping | :done
+
+  # client
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @spec report(module | pid, {atom, Params.t(), keyword}) :: :ok
+  def report(pid, message) do
+    GenServer.cast(pid, message)
+  end
+
+  # server
+
+  def init(:ok) do
+    {:ok, :ok}
+  end
+
+  def handle_cast({:starting, params, _opts}, :ok) do
+    IO.puts("starting #{params.output_filename}")
+    {:noreply, :ok}
+  end
+
+  def handle_cast({:writing, params, opts}, :ok) do
+    chunk_number = Keyword.get(opts, :chunk_number)
+    IO.puts("writing #{chunk_number}/#{params.chunk_count} to #{params.ppm_filename}")
+    {:noreply, :ok}
+  end
+
+  def handle_cast({:skipping, params, opts}, :ok) do
+    reason = Keyword.get(opts, :reason)
+    IO.puts("skipping #{params.output_filename}: #{reason}")
+    {:noreply, :ok}
+  end
+
+  def handle_cast({:done, params, _opts}, :ok) do
+    IO.puts("finished #{params.output_filename}")
+    {:noreply, :ok}
+  end
+end

--- a/elixir/lib/fractals/reporters/stdout.ex
+++ b/elixir/lib/fractals/reporters/stdout.ex
@@ -5,37 +5,41 @@ defmodule Fractals.Reporters.Stdout do
 
   use GenServer
 
-  @type tag :: :starting | :writing | :skipping | :done
-
   # client
 
+  @spec start_link(any) :: GenServer.on_start()
   def start_link(_) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
   # server
 
+  @impl GenServer
   def init(:ok) do
     {:ok, :ok}
   end
 
+  @impl GenServer
   def handle_cast({:starting, params, _opts}, :ok) do
     IO.puts("starting #{params.output_filename}")
     {:noreply, :ok}
   end
 
+  @impl GenServer
   def handle_cast({:writing, params, opts}, :ok) do
     chunk_number = Keyword.get(opts, :chunk_number)
     IO.puts("writing #{chunk_number}/#{params.chunk_count} to #{params.ppm_filename}")
     {:noreply, :ok}
   end
 
+  @impl GenServer
   def handle_cast({:skipping, params, opts}, :ok) do
     reason = Keyword.get(opts, :reason)
     IO.puts("skipping #{params.output_filename}: #{reason}")
     {:noreply, :ok}
   end
 
+  @impl GenServer
   def handle_cast({:done, params, _opts}, :ok) do
     IO.puts("finished #{params.output_filename}")
     {:noreply, :ok}

--- a/elixir/lib/fractals/reporters/stdout.ex
+++ b/elixir/lib/fractals/reporters/stdout.ex
@@ -28,7 +28,11 @@ defmodule Fractals.Reporters.Stdout do
   @impl GenServer
   def handle_cast({:writing, params, opts}, :ok) do
     chunk_number = Keyword.get(opts, :chunk_number)
-    IO.puts("writing #{chunk_number}/#{params.chunk_count} to #{params.ppm_filename}")
+
+    if Integer.mod(chunk_number, 20) == 0 or chunk_number == params.chunk_count do
+      IO.puts("writing #{chunk_number}/#{params.chunk_count} to #{params.ppm_filename}")
+    end
+
     {:noreply, :ok}
   end
 

--- a/elixir/lib/fractals/reporters/supervisor.ex
+++ b/elixir/lib/fractals/reporters/supervisor.ex
@@ -1,0 +1,28 @@
+defmodule Fractals.Reporters.Supervisor do
+  @moduledoc """
+  Supervises reporters.
+
+  Use `Fractals.Reporters.Broadcaster.add_reporter/2` to add more reporters.
+  """
+
+  use DynamicSupervisor
+
+  @spec start_link([module]) :: Supervisor.on_start()
+  def start_link(reporters \\ []) do
+    DynamicSupervisor.start_link(__MODULE__, reporters, name: __MODULE__)
+  end
+
+  def add_reporter(reporter, args \\ []) do
+    child_spec = %{
+      id: reporter,
+      start: {reporter, :start_link, [args]}
+    }
+
+    DynamicSupervisor.start_child(__MODULE__, child_spec)
+  end
+
+  @impl true
+  def init(_arg) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/elixir/test/fractals/conversion_worker_test.exs
+++ b/elixir/test/fractals/conversion_worker_test.exs
@@ -9,8 +9,6 @@ defmodule Fractals.ConversionWorkerTest do
     convert = fn source, destination -> send(test_pid, {source, destination}) end
     broadcast = fn tag, params, opts -> send(test_pid, {:test_report, {tag, params, opts}}) end
 
-    params = %Params{source_pid: test_pid}
-
     {:ok, pid} =
       ConversionWorker.start_link(
         convert: convert,
@@ -18,19 +16,19 @@ defmodule Fractals.ConversionWorkerTest do
         name: :conversion_worker_under_test
       )
 
-    [pid: pid, params: params]
+    [pid: pid]
   end
 
   describe "&convert/1" do
-    test "reports done for a PPM file", %{pid: pid, params: params} do
-      params = %Params{params | output_filename: "output.ppm"}
+    test "reports done for a PPM file", %{pid: pid} do
+      params = %Params{output_filename: "output.ppm"}
       ConversionWorker.convert(pid, params)
 
       assert_receive {:test_report, {:done, _pid, _params}}
     end
 
-    test "calls converter and reports done for a PNG file", %{pid: pid, params: params} do
-      params = %Params{params | output_filename: "output.png"}
+    test "calls converter and reports done for a PNG file", %{pid: pid} do
+      params = %Params{output_filename: "output.png"}
       ConversionWorker.convert(pid, params)
 
       assert_receive {"output.ppm", "output.png"}

--- a/elixir/test/fractals/output_worker_test.exs
+++ b/elixir/test/fractals/output_worker_test.exs
@@ -52,7 +52,6 @@ defmodule Fractals.OutputWorkerTest do
   defp params(context) do
     params = %Params{
       output_pid: context.output_pid,
-      source_pid: self(),
       size: %Size{width: 3, height: 1},
       chunk_count: context.chunk_count
     }

--- a/elixir/test/integration_test.exs
+++ b/elixir/test/integration_test.exs
@@ -40,8 +40,6 @@ defmodule Fractals.IntegrationTest do
       )
 
     ExUnit.CaptureIO.capture_io(fn ->
-      Fractals.Reporters.Supervisor.add_reporter(Fractals.Reporters.Broadcaster)
-
       Fractals.Reporters.Broadcaster.add_reporter(Fractals.Reporters.FilenameCountdown,
         filenames: [@mandelbrot_input_filename],
         for: self()

--- a/elixir/test/integration_test.exs
+++ b/elixir/test/integration_test.exs
@@ -28,16 +28,20 @@ defmodule Fractals.IntegrationTest do
   end
 
   test "generates a pretty picture" do
+    Fractals.Reporters.FilenameCountdown.start_link(
+      filenames: @mandelbrot_input_filename,
+      for: self()
+    )
+
     params =
       Fractals.Params.process(
         output_directory: "test/images",
-        params_filename: @mandelbrot_input_filename,
-        source_pid: self()
+        params_filename: @mandelbrot_input_filename
       )
 
     ExUnit.CaptureIO.capture_io(fn ->
       Fractals.fractalize(params)
-      Fractals.CLI.watch([@mandelbrot_input_filename])
+      Fractals.CLI.wait()
     end)
 
     output = File.read!(@mandelbrot_output_filename)

--- a/elixir/test/integration_test.exs
+++ b/elixir/test/integration_test.exs
@@ -40,6 +40,13 @@ defmodule Fractals.IntegrationTest do
       )
 
     ExUnit.CaptureIO.capture_io(fn ->
+      Fractals.Reporters.Supervisor.add_reporter(Fractals.Reporters.Broadcaster)
+
+      Fractals.Reporters.Broadcaster.add_reporter(Fractals.Reporters.FilenameCountdown,
+        filenames: [@mandelbrot_input_filename],
+        for: self()
+      )
+
       Fractals.fractalize(params)
       Fractals.CLI.wait()
     end)

--- a/yaml/small.yml
+++ b/yaml/small.yml
@@ -1,0 +1,5 @@
+fractal: Mandelbrot
+color: BlackOnWhite
+size: 10x10
+upperLeft: -2.0+1.2i
+lowerRight: 1.2+-1.2i


### PR DESCRIPTION
Three reporters:

* `FilenameCountdown` takes the names of all params files, and as fractals are reported as "done", it takes the name of the params file out of its state.  When it has no more filenames, it sends a message to the CLI that it can stop.
* `Stdout` outputs messages to stdout based on the reported messages.
* `Broadcaster` keeps a list of reporters and relays messages to all of them.

Reporters should be registered with `Broadcaster` (which will start and add them to the supervisor).  Messages should be sent just to `Broadcaster`.